### PR TITLE
Update imports in .php-cs-fixer.dist.php, fix comments in ParameterBag

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,7 +14,10 @@ return (new PhpCsFixer\Config())
         'declare_strict_types'                  => true,
         'array_syntax'                          => ['syntax' => 'short'],
         'no_unused_imports'                     => true,
-        'ordered_imports'                       => ['sort_algorithm' => 'alpha'],
+        'ordered_imports'                       => [
+            'sort_algorithm' => 'alpha',
+            'imports_order'  => ['class', 'function', 'const'],
+        ],
         'single_quote'                          => true,
         'trailing_comma_in_multiline'           => true,
         'no_trailing_whitespace'                => true,

--- a/src/ParameterBag.php
+++ b/src/ParameterBag.php
@@ -120,7 +120,7 @@ class ParameterBag implements ParameterBagInterface
      *                                         - `caseInsensitive` (bool, default false)
      *
      * @throws ParameterBagInvalidArgumentException If $options contains
-     *         any unrecognised key.
+     *                                              any unrecognised key.
      */
     public function __construct(array $data = [], array $options = [])
     {
@@ -375,6 +375,7 @@ class ParameterBag implements ParameterBagInterface
      * {@see \ArrayAccess::offsetGet()} — delegates to {@see self::get()}.
      *
      * @param array-key $offset
+     *
      * @return mixed
      */
     #[\ReturnTypeWillChange]
@@ -478,6 +479,7 @@ class ParameterBag implements ParameterBagInterface
      * never modified.
      *
      * @param array<array-key, mixed> $array
+     *
      * @return array<array-key, mixed>
      */
     private function normalizeKeys(array $array): array
@@ -521,6 +523,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @param mixed                   $value
      * @param array<array-key, mixed> $parameters
+     *
      * @return array<array-key, mixed>
      */
     private function multiSubParameterSet(string $key, $value, array $parameters): array
@@ -547,6 +550,7 @@ class ParameterBag implements ParameterBagInterface
      * the rebuilt subtree.
      *
      * @param array<array-key, mixed> $parameters
+     *
      * @return array<array-key, mixed>
      */
     private function multiSubParameterRemove(string $key, array $parameters): array

--- a/src/ParameterBagInterface.php
+++ b/src/ParameterBagInterface.php
@@ -159,7 +159,7 @@ interface ParameterBagInterface extends \ArrayAccess, \Countable, \IteratorAggre
      * @return $this
      *
      * @throws ParameterBagInvalidArgumentException If any argument is
-     *         neither an array nor a {@see ParameterBagInterface}.
+     *                                              neither an array nor a {@see ParameterBagInterface}.
      */
     public function merge(...$merge): self;
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please:
- Read CONTRIBUTING.md if you haven't: https://github.com/InitPHP/.github/blob/main/CONTRIBUTING.md
- Open one PR per repository — cross-repo changes need a separate PR in each repo, linked in the description.
- Keep the PR focused on one change. If you spotted unrelated improvements, please send them as separate PRs.
-->

## Summary

<!-- One or two sentences: what does this PR do, and why? Focus on the why — the diff already shows the what. -->

## Type of change

<!-- Check all that apply. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behaviour in an incompatible way)
- [ ] 📖 Documentation update
- [ ] 🔧 Refactor / internal change (no behaviour change)
- [ ] ✅ Tests only
- [ ] 🚀 CI / build / tooling

## Linked issues

<!-- e.g. "Closes #123" / "Refs #456" / "Related: InitPHP/HTTP#42" for cross-repo work. -->

## How was this tested?

<!--
Describe the tests you ran and any manual verification steps.
Paste relevant output (test runs, before/after) if helpful.
If this PR adds or changes behaviour, it should also add or update a test.
-->

## Breaking changes

<!--
If you checked "Breaking change" above, describe:
- What breaks (which public API, signature, behaviour)
- The migration path users need to take
- Whether a BC shim (class_alias, deprecation wrapper) was added or considered
Otherwise, write "N/A".
-->

## Checklist

- [ ] Code follows PSR-12 and the project's existing style (PHP-CS-Fixer if available, no warnings)
- [ ] `declare(strict_types=1);` is present in any new PHP files in `src/`
- [ ] Public methods have proper type declarations (parameters and return types)
- [ ] Tests cover the change — added new tests or updated existing ones (N/A for docs-only PRs)
- [ ] PHPStan passes locally at the level configured in the package
- [ ] PHPUnit passes locally (`composer test` or `vendor/bin/phpunit`)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have read and agree to the [Code of Conduct](https://github.com/InitPHP/.github/blob/main/CODE_OF_CONDUCT.md)
